### PR TITLE
Corrected readme desc of property for private_key to private_key_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ your Okta administrator for more information._
 ### Private Key Authentication
 
 External browser authentication can be selected by supplying `snowflake_jwt` as your authenticator. The filepath to a
-Snowflake user-encrypted private key must be supplied as `private-key` in the [connections.toml](#connectionstoml-file)
+Snowflake user-encrypted private key must be supplied as `private_key_file` in the [connections.toml](#connectionstoml-file)
 file. If the private key file is password protected, supply the password as `private_key_file_pwd` in
 the [connections.toml](#connectionstoml-file) file. If the variable is not set, the Snowflake Python connector will
 assume the private key is not encrypted.


### PR DESCRIPTION
As per the snowflake python connector documentation the toml reference to the user private key file should be private_key_file and not private_key as described in the readme.
ref:
https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#using-key-pair-authentication-and-key-pair-rotation